### PR TITLE
add constants for module errors

### DIFF
--- a/luxtronik.js
+++ b/luxtronik.js
@@ -269,7 +269,7 @@ Luxtronik.prototype._processData = function () {
     if (typeof heatpumpParameters === 'undefined' ||
         typeof heatpumpValues === 'undefined' ||
         typeof heatpumpVisibility === 'undefined') {
-        return this.receivy.callback(new Error('Unexpected Data'));
+        return this.receivy.callback(types.moduleErrors.unexpectedData);
     }
     if (this.receivy.rawdata) {
         return this.receivy.callback(null, {
@@ -398,7 +398,7 @@ Luxtronik.prototype._startRead = function (rawdata, callback) {
                     this.client = null;
                     return process.nextTick(
                         function () {
-                            this.receivy.callback(new Error('heatpump busy'));
+                            this.receivy.callback(types.moduleErrors.heatpumpBusy);
                         }.bind(this)
                     );
                 } else {
@@ -569,4 +569,9 @@ const createConnection = function (host, port) {
     return new Luxtronik(host, port);
 };
 
+const moduleErrors = function () {
+    return types.moduleErrors;
+};
+
 module.exports.createConnection = createConnection;
+module.exports.moduleErrors = moduleErrors;

--- a/types.js
+++ b/types.js
@@ -218,5 +218,11 @@ module.exports = {
         '8': 'Untere Einsatzgrenze',
         '9': 'Keine Anforderung',
         '-1': 'Unbekannte Abschaltung'
+    }),
+
+    moduleErrors: Object.freeze({
+        unexpectedData: new Error ('Unexpected Data'),
+        heatpumpBusy: new Error ('Heatpump Busy')
     })
+
 };


### PR DESCRIPTION
Hi coolchip

I updated my pimatic module with your version 1.0.0 and had to modify the error handling of the busy state since you renamed it after 0.12.

It would be nice if I could refer to the errors used in your library by accessing it via constant.

I'm not sure if my implementation is the best. 
What do your think?