### PR TITLE
Read timer tables: heating/hot operation and hot water circ pump

### DIFF
--- a/luxtronik.js
+++ b/luxtronik.js
@@ -285,19 +285,20 @@ function processParameters(heatpumpParameters, heatpumpVisibility) {
         'hotWaterOperationTimerTableSelected': heatpumpParameters[405],
         'hotWaterOperationTimerTableSelectedString': utils.createTimerTableTypeString(heatpumpParameters[405]), // string representation
 
+        // Important: hot water operation table specifies operation in inverse logic. Therefore swap the on/off times.
         // hot water operation table 0: week.
-        'hotWaterOperationTimerTableWeek': utils.createTimerTable(heatpumpParameters, 406, 5), // 406..415
+        'hotWaterOperationTimerTableWeek': utils.createTimerTable(heatpumpParameters, 406, 5, true), // 406..415
         // hot water operation table 1: 5+2
-        'hotWaterOperationTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 416, 5), // 416..425
-        'hotWaterOperationTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 426, 5), // 426..435
+        'hotWaterOperationTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 416, 5, true), // 416..425
+        'hotWaterOperationTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 426, 5, true), // 426..435
         // hot water operation table 2: day
-        'hotWaterOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 436, 5), // 436..445
-        'hotWaterOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 446, 5), // 446..455
-        'hotWaterOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 456, 5), // 456..465
-        'hotWaterOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 466, 5), // 466..475
-        'hotWaterOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 476, 5), // 476..485
-        'hotWaterOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 486, 5), // 486..495
-        'hotWaterOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 496, 5), // 496..505
+        'hotWaterOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 436, 5, true), // 436..445
+        'hotWaterOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 446, 5, true), // 446..455
+        'hotWaterOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 456, 5, true), // 456..465
+        'hotWaterOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 466, 5, true), // 466..475
+        'hotWaterOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 476, 5, true), // 476..485
+        'hotWaterOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 486, 5, true), // 486..495
+        'hotWaterOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 496, 5, true), // 496..505
 
         // Activated timer table for hot water circulation pump.
         // Possible values: 0=week (monday-sunday), 1=5+2 (monday-friday), 2=days (mo, tue, ...)

--- a/luxtronik.js
+++ b/luxtronik.js
@@ -272,31 +272,32 @@ function processParameters(heatpumpParameters, heatpumpVisibility) {
         'heatingOperationTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 229, 3), // 229..234
         'heatingOperationTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 235, 3), // 235..240
         // heating operation table 2: day
-        'heatingOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 241, 3), // 241..246
-        'heatingOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 247, 3), // 247..252
-        'heatingOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 253, 3), // 253..258
-        'heatingOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 259, 3), // 259..264
-        'heatingOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 265, 3), // 265..270
-        'heatingOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 271, 3), // 271..276
-        'heatingOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 277, 3), // 277..282
+        'heatingOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 241, 3), // 241..246
+        'heatingOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 247, 3), // 247..252
+        'heatingOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 253, 3), // 253..258
+        'heatingOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 259, 3), // 259..264
+        'heatingOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 265, 3), // 265..270
+        'heatingOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 271, 3), // 271..276
+        'heatingOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 277, 3), // 277..282
 
         // Activated timer table for hot water operation.
         // Possible values: 0=week (monday-sunday), 1=5+2 (monday-friday), 2=days (mo, tue, ...)
         'hotWaterOperationTimerTableSelected': heatpumpParameters[405],
         'hotWaterOperationTimerTableSelectedString': utils.createTimerTableTypeString(heatpumpParameters[405]), // string representation
-        // hot water operation table 0: week
+
+        // hot water operation table 0: week.
         'hotWaterOperationTimerTableWeek': utils.createTimerTable(heatpumpParameters, 406, 5), // 406..415
         // hot water operation table 1: 5+2
         'hotWaterOperationTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 416, 5), // 416..425
         'hotWaterOperationTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 426, 5), // 426..435
         // hot water operation table 2: day
-        'hotWaterOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 436, 5), // 436..445
-        'hotWaterOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 446, 5), // 446..455
-        'hotWaterOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 456, 5), // 456..465
-        'hotWaterOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 466, 5), // 466..475
-        'hotWaterOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 476, 5), // 476..485
-        'hotWaterOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 486, 5), // 486..495
-        'hotWaterOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 496, 5), // 496..505
+        'hotWaterOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 436, 5), // 436..445
+        'hotWaterOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 446, 5), // 446..455
+        'hotWaterOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 456, 5), // 456..465
+        'hotWaterOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 466, 5), // 466..475
+        'hotWaterOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 476, 5), // 476..485
+        'hotWaterOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 486, 5), // 486..495
+        'hotWaterOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 496, 5), // 496..505
 
         // Activated timer table for hot water circulation pump.
         // Possible values: 0=week (monday-sunday), 1=5+2 (monday-friday), 2=days (mo, tue, ...)
@@ -308,13 +309,13 @@ function processParameters(heatpumpParameters, heatpumpVisibility) {
         'hotWaterCircPumpTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 517, 5), // 517..526
         'hotWaterCircPumpTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 527, 5), // 527..536
         // hot water circulation pump table 2: day
-        'hotWaterCircPumpTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 537, 5), // 537..546
-        'hotWaterCircPumpTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 547, 5), // 547..556
-        'hotWaterCircPumpTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 557, 5), // 557..566
-        'hotWaterCircPumpTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 567, 5), // 567..576
-        'hotWaterCircPumpTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 577, 5), // 577..586
-        'hotWaterCircPumpTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 587, 5), // 587..596
-        'hotWaterCircPumpTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 597, 5), // 597..606
+        'hotWaterCircPumpTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 537, 5), // 537..546
+        'hotWaterCircPumpTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 547, 5), // 547..556
+        'hotWaterCircPumpTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 557, 5), // 557..566
+        'hotWaterCircPumpTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 567, 5), // 567..576
+        'hotWaterCircPumpTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 577, 5), // 577..586
+        'hotWaterCircPumpTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 587, 5), // 587..596
+        'hotWaterCircPumpTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 597, 5), // 597..606
 
         'hotWaterCircPumpOnTime': heatpumpParameters[697],  // Time in minutes the circ pump is turned on within one cycle.
         'hotWaterCircPumpOffTime': heatpumpParameters[698], // Time in minutes the circ pump is turned off within one cycle.

--- a/luxtronik.js
+++ b/luxtronik.js
@@ -259,6 +259,65 @@ function processParameters(heatpumpParameters, heatpumpVisibility) {
 
         'heating_system_circ_pump_voltage_nominal': heatpumpParameters[867] / 100,
         'heating_system_circ_pump_voltage_minimal': heatpumpParameters[868] / 100,
+
+        // ---- Timer table configurations ----
+
+        // Activated timer table for heating operation.
+        // Possible values: 0=week (monday-sunday), 1=5+2 (monday-friday), 2=days (mo, tue, ...)
+        'heatingOperationTimerTableSelected': heatpumpParameters[222],
+        'heatingOperationTimerTableSelectedString': utils.createTimerTableTypeString(heatpumpParameters[222]), // string representation
+        // heating operation table 0: week
+        'heatingOperationTimerTableWeek': utils.createTimerTable(heatpumpParameters, 223, 3), // 223..528
+        // heating operation table 1: 5+2
+        'heatingOperationTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 229, 3), // 229..234
+        'heatingOperationTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 235, 3), // 235..240
+        // heating operation table 2: day
+        'heatingOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 241, 3), // 241..246
+        'heatingOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 247, 3), // 247..252
+        'heatingOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 253, 3), // 253..258
+        'heatingOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 259, 3), // 259..264
+        'heatingOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 265, 3), // 265..270
+        'heatingOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 271, 3), // 271..276
+        'heatingOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 277, 3), // 277..282
+
+        // Activated timer table for hot water operation.
+        // Possible values: 0=week (monday-sunday), 1=5+2 (monday-friday), 2=days (mo, tue, ...)
+        'hotWaterOperationTimerTableSelected': heatpumpParameters[405],
+        'hotWaterOperationTimerTableSelectedString': utils.createTimerTableTypeString(heatpumpParameters[405]), // string representation
+        // hot water operation table 0: week
+        'hotWaterOperationTimerTableWeek': utils.createTimerTable(heatpumpParameters, 406, 5), // 406..415
+        // hot water operation table 1: 5+2
+        'hotWaterOperationTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 416, 5), // 416..425
+        'hotWaterOperationTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 426, 5), // 426..435
+        // hot water operation table 2: day
+        'hotWaterOperationTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 436, 5), // 436..445
+        'hotWaterOperationTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 446, 5), // 446..455
+        'hotWaterOperationTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 456, 5), // 456..465
+        'hotWaterOperationTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 466, 5), // 466..475
+        'hotWaterOperationTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 476, 5), // 476..485
+        'hotWaterOperationTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 486, 5), // 486..495
+        'hotWaterOperationTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 496, 5), // 496..505
+
+        // Activated timer table for hot water circulation pump.
+        // Possible values: 0=week (monday-sunday), 1=5+2 (monday-friday), 2=days (mo, tue, ...)
+        'hotWaterCircPumpTimerTableSelected': heatpumpParameters[506],
+        'hotWaterCircPumpTimerTableSelectedString': utils.createTimerTableTypeString(heatpumpParameters[506]), // string representation
+        // hot water circulation pump table 0: week
+        'hotWaterCircPumpTimerTableWeek': utils.createTimerTable(heatpumpParameters, 507, 5), // 507..516
+        // hot water circulation pump table 1: 5+2
+        'hotWaterCircPumpTimerTable52MonFri': utils.createTimerTable(heatpumpParameters, 517, 5), // 517..526
+        'hotWaterCircPumpTimerTable52SatSun': utils.createTimerTable(heatpumpParameters, 527, 5), // 527..536
+        // hot water circulation pump table 2: day
+        'hotWaterCircPumpTimerTableDayMonday': utils.createTimerTable(heatpumpParameters, 537, 5), // 537..546
+        'hotWaterCircPumpTimerTableDayTuesday': utils.createTimerTable(heatpumpParameters, 547, 5), // 547..556
+        'hotWaterCircPumpTimerTableDayWednesday': utils.createTimerTable(heatpumpParameters, 557, 5), // 557..566
+        'hotWaterCircPumpTimerTableDayThursday': utils.createTimerTable(heatpumpParameters, 567, 5), // 567..576
+        'hotWaterCircPumpTimerTableDayFriday': utils.createTimerTable(heatpumpParameters, 577, 5), // 577..586
+        'hotWaterCircPumpTimerTableDaySaturday': utils.createTimerTable(heatpumpParameters, 587, 5), // 587..596
+        'hotWaterCircPumpTimerTableDaySunday': utils.createTimerTable(heatpumpParameters, 597, 5), // 597..606
+
+        'hotWaterCircPumpOnTime': heatpumpParameters[697],  // Time in minutes the circ pump is turned on within one cycle.
+        'hotWaterCircPumpOffTime': heatpumpParameters[698], // Time in minutes the circ pump is turned off within one cycle.
     };
 }
 

--- a/types.js
+++ b/types.js
@@ -129,6 +129,13 @@ module.exports = {
         '-1': 'Unbekannter Typ'
     }),
 
+
+    timerTableTypes: Object.freeze({
+        '0': 'Woche (Mo-So)',
+        '1': '5+2 (Mo-Fr, Sa-So)',
+        '2': 'Tage (Mo, Di, ...)'
+    }),
+
     errorCodes: Object.freeze({
         '701': 'Niederdruckstoerung - Bitte Inst. rufen',
         '702': 'Niederdrucksperre - RESET automatisch',

--- a/utils.js
+++ b/utils.js
@@ -172,6 +172,36 @@ function limitRange(value, min, max) {
     return value;
 }
 
+function createTimerTableTypeString(value) {
+    let tableStr = ''
+
+    if (types.timerTableTypes.hasOwnProperty(value)) {
+        tableStr = types.timerTableTypes[value];
+    } else {
+        tableStr = 'unbekannt';
+    }
+
+    return tableStr;
+}
+
+function secondsToTimeString(value) {
+    const timeMilliseconds = new Date(value * 1000);
+    const timeStr = timeMilliseconds.toISOString().substr(11, 5);
+    return timeStr;
+}
+
+function createTimerTable(parameters, startindex, rows) {
+    let timerTable = [];
+
+    for(let rowindex = 0; rowindex < rows; rowindex++) {
+        timerTable.push({"on": secondsToTimeString(parameters[startindex + (rowindex * 2)]),
+                         "off": secondsToTimeString(parameters[startindex + (rowindex * 2) + 1])});
+    }
+
+    return timerTable;
+}
+
+
 module.exports = {
     createFirmwareString,
     int2ipAddress,
@@ -186,5 +216,7 @@ module.exports = {
     value2LuxtronikSetTemperatureValue,
     value2LuxtronikSetHundrethValue,
     isValidOperationMode,
-    limitRange
+    limitRange,
+    createTimerTableTypeString,
+    createTimerTable
 };

--- a/utils.js
+++ b/utils.js
@@ -190,12 +190,18 @@ function secondsToTimeString(value) {
     return timeStr;
 }
 
-function createTimerTable(parameters, startindex, rows) {
+function createTimerTable(parameters, startindex, rows, swapOnOff = false) {
     let timerTable = [];
 
     for(let rowindex = 0; rowindex < rows; rowindex++) {
-        timerTable.push({"on": secondsToTimeString(parameters[startindex + (rowindex * 2)]),
-                         "off": secondsToTimeString(parameters[startindex + (rowindex * 2) + 1])});
+        let onTime = secondsToTimeString(parameters[startindex + (rowindex * 2)]);
+        let offTime = secondsToTimeString(parameters[startindex + (rowindex * 2) + 1]);
+        if(swapOnOff === true) {
+            const tmp = onTime;
+            onTime = offTime;
+            offTime = tmp;
+        }
+        timerTable.push({"on": onTime, "off": offTime});
     }
 
     return timerTable;

--- a/utils.js
+++ b/utils.js
@@ -201,7 +201,7 @@ function createTimerTable(parameters, startindex, rows, swapOnOff = false) {
             onTime = offTime;
             offTime = tmp;
         }
-        timerTable.push({"on": onTime, "off": offTime});
+        timerTable.push({on: onTime, off: offTime});
     }
 
     return timerTable;


### PR DESCRIPTION
Hello @coolchip I implemented parsing for the heatpump parameter containing the timer table settings (Zeitschaltuhr) for hot water operation, heating operation and hot water circulation pump.

I hope you like the changes. Please tell me if you see any issue or things which could be improved.

Outlook: My main motivation is to make the hot water circ pump controlable via node-red-contrib-luxtronik2. I want to disable the whole hot water circ pump if nobody is present at home/certain room etc. But for the moment this merge requests focuses on reading the current settings. Write operations I will investigate next.