### PR TITLE
Support RAW write operations

### DIFF
--- a/luxtronik.js
+++ b/luxtronik.js
@@ -570,6 +570,7 @@ Luxtronik.prototype._handleWriteCommand = function (parameterName, realValue, ca
     });
 
     const set = writeParameters.hasOwnProperty(parameterName) ? writeParameters[parameterName] : writeParameters.wrongName;
+
     if (typeof set.setParameter !== 'undefined') {
         const setParameter = set.setParameter;
         const setValue = set.setValue;
@@ -601,6 +602,18 @@ Luxtronik.prototype.write = function (parameterName, realValue, callback) {
         callback = function () {};
     }
     this._handleWriteCommand(parameterName, realValue, callback);
+};
+
+Luxtronik.prototype.writeRaw = function (parameterNumber, rawValue, callback) {
+    if (typeof callback === 'undefined') {
+        callback = function () {};
+    }
+
+    if((typeof parameterNumber === 'number') && (typeof rawValue === 'number')) {
+        this._startWrite(parameterNumber, rawValue, callback);
+    } else {
+        callback(new Error('RAW write operation requires parameter and value as number!'));
+    }
 };
 
 const createConnection = function (host, port) {


### PR DESCRIPTION
Hi @coolchip as mentioned in #19 my motivation is to control the hot water circ pump via software (e.g. turn off if nobody is present).
As the timer tables are based on dozens of parameter I think it makes not much sense to provide all these single timer table parameters via key/value pair as done in `_handleWriteCommand()`.
To make the node currently more flexible to use for "power user" I thought a generic/RAW write operation mode would be helpful.

The related [node-red-contrib-luxtronik2](https://github.com/coolchip/node-red-contrib-luxtronik2) I extend with a support of `msg.raw_parameter` which simply takes the parameter as a number and the parameter value from `msg.payload`.
If you like such a RAW write mode I could provide this change as merge request too.