### PR TITLE
Added: Options for dearate

### DIFF
--- a/luxtronik.js
+++ b/luxtronik.js
@@ -260,6 +260,10 @@ function processParameters(heatpumpParameters, heatpumpVisibility) {
 
         'hotWaterCircPumpDeaerate': (heatpumpVisibility[167] === 1) ? heatpumpParameters[684] : 'no', // #61
 
+        'solarPumpDeaerate': (heatpumpVisibility[167] === 1) ? heatpumpParameters[688] : 'no',
+
+        'runDeaerate': (heatpumpVisibility[167] === 1) ? heatpumpParameters[158] : 'no',
+
         'heatingLimit': heatpumpParameters[699], // #11
         'thresholdHeatingLimit': heatpumpParameters[700] / 10, // #21
 
@@ -386,6 +390,14 @@ Luxtronik.prototype._processData = function () {
 
     if (parameters.hotWaterCircPumpDeaerate !== 'no') {
         parameters.hotWaterCircPumpDeaerate = parameters.hotWaterCircPumpDeaerate ? 'on' : 'off';
+    }
+
+    if (parameters.solarPumpDeaerate !== 'no') {
+        parameters.solarPumpDeaerate = parameters.solarPumpDeaerate ? 'on' : 'off';
+    }
+
+    if (parameters.runDeaerate !== 'no') {
+        parameters.runDeaerate = parameters.runDeaerate ? 'on' : 'off';
     }
 
     // Consider also heating limit
@@ -649,6 +661,18 @@ Luxtronik.prototype._handleWriteCommand = function (parameterName, realValue, ca
         'cooling_inlet_temp': {
             setParameter: 132,
             setValue: utils.value2LuxtronikSetTemperatureValue(realValue)
+        },
+        'runDeaerate': {
+            setParameter: 158,
+            setValue: realValue
+        },
+        'hotWaterCircPumpDeaerate': {
+            setParameter: 684,
+            setValue: realValue
+        },
+        'solarPumpDeaerate': {
+            setParameter: 688,
+            setValue: realValue
         },
         'cooling_start': {
             setParameter: 850,


### PR DESCRIPTION
* read/set runDearate
* read/set solarPumpDeaerate
* set hotWaterCircPumpDeaerate

Note: you need to set "runDearate" directly after you set the related pump, otherwise the Lux will not start the pump!

Example code:

const value= 1;
pump.write('solarPumpDeaerate', value, function (err, data) {
    if (err) {
        console.log(err);
    } else {
        console.log(data);
        console.log("done");
        pump.write('runDeaerate', value, function (err, data) {
            if (err) {
                console.log(err);
            } else {
                console.log(data);
                console.log("done");
            }
        });
    }
});
